### PR TITLE
Add pin for extruder 1 hotend fan

### DIFF
--- a/config/printer-makerbot-replicator2x-2012.cfg
+++ b/config/printer-makerbot-replicator2x-2012.cfg
@@ -86,6 +86,10 @@ screw3: 197, 3
 pin: PH4
 heater: extruder
 
+#[heater_fan extruder1_fan]
+#pin: PE4
+#heater: extruder1
+
 [fan]
 pin: PG5
 


### PR DESCRIPTION
Extruder 1 hotend fan will now turn on when extruder 1 is heating or is above 50C. This has been tested successfully on 3 Makerbot Replicator 2Xs.