### PR TITLE
Fix "fault" typo

### DIFF
--- a/klippy/extras/ads1118_thermocouple.py
+++ b/klippy/extras/ads1118_thermocouple.py
@@ -70,7 +70,7 @@ class ADS1118_Thermocouple(object):
             self.report_fault("ADS1118: Cold Junction High Fault")
         if fault & ADS1118_COLD_JUNCTION_LOW_FAULT:
             self.report_fault("ADS1118: Cold Junction Low Fault")
-        if falut & ADS1118_CONFIG_READ_ERROR:
+        if fault & ADS1118_CONFIG_READ_ERROR:
             self.report_fault("ADS1118: Config register readback is incorect")
     def calc_temp(self, adc_mv, cj_temp, fault):
         try:


### PR DESCRIPTION
Noticed a very small typo in an if statement while browsing recent commits - this PR changes "falut" to "fault" accordingly