### PR TITLE
Fix small typos

### DIFF
--- a/klippy/extras/ads1118.py
+++ b/klippy/extras/ads1118.py
@@ -14,7 +14,7 @@ MAX_INVALID_COUNT = 3
 # ADS1118
 # This class implements the primary device that is reponsible
 # for registering a chip with two pins (channels) and the
-# loop that queries the cold junction temperatre and up to two
+# loop that queries the cold junction temperature and up to two
 # thermocouple voltages
 ######################################################################
 

--- a/klippy/extras/ads1118_thermocouple.py
+++ b/klippy/extras/ads1118_thermocouple.py
@@ -71,7 +71,7 @@ class ADS1118_Thermocouple(object):
         if fault & ADS1118_COLD_JUNCTION_LOW_FAULT:
             self.report_fault("ADS1118: Cold Junction Low Fault")
         if fault & ADS1118_CONFIG_READ_ERROR:
-            self.report_fault("ADS1118: Config register readback is incorect")
+            self.report_fault("ADS1118: Config register readback is incorrect")
     def calc_temp(self, adc_mv, cj_temp, fault):
         try:
             adc_mv = adc_mv * ADS1118_MULT


### PR DESCRIPTION
I noticed two small typos while looking at the new commits. Neither are consequential in terms of code operation, just little polishing touches.

Fix typo in comment section of ads1118.py

Changes "temperatre" to "temperature"

Fix typo in error message in ads1118_thermocouple.py

Changes "incorect" to "incorrect"